### PR TITLE
Fix missing recent Misc sessions in recording resources

### DIFF
--- a/fapi/utils/resources_utils.py
+++ b/fapi/utils/resources_utils.py
@@ -121,20 +121,37 @@ def fetch_sessions_by_type_orm(db: Session, course_id: int, session_type: str, t
     if team not in ["admin", "instructor"] and db_session_type not in allowed_types:
         return []
 
-    query = (
-        select(SessionORM)
-        .join(CourseSubject, SessionORM.subject_id == CourseSubject.subject_id)
-        .where(
-            SessionORM.subject_id != 0,
-            CourseSubject.course_id == course_id,
-            SessionORM.type == db_session_type,
-            or_(
-                CourseSubject.course_id != 3,
-                SessionORM.sessiondate >= "2024-01-01"
+    if db_session_type == "Misc":
+        # Misc is used as a shared bucket across courses in the current data,
+        # so filtering it by the selected course hides newer entries whose
+        # subject_id points at QA/UI subjects even though they should still
+        # appear in the Misc recordings list.
+        query = (
+            select(SessionORM)
+            .where(
+                SessionORM.type == db_session_type,
+                or_(
+                    course_id != 3,
+                    SessionORM.sessiondate >= "2024-01-01",
+                ),
             )
+            .order_by(SessionORM.sessiondate.desc())
         )
-        .order_by(SessionORM.sessiondate.desc())
-    )
+    else:
+        query = (
+            select(SessionORM)
+            .join(CourseSubject, SessionORM.subject_id == CourseSubject.subject_id)
+            .where(
+                SessionORM.subject_id != 0,
+                CourseSubject.course_id == course_id,
+                SessionORM.type == db_session_type,
+                or_(
+                    CourseSubject.course_id != 3,
+                    SessionORM.sessiondate >= "2024-01-01"
+                )
+            )
+            .order_by(SessionORM.sessiondate.desc())
+        )
 
     result = db.execute(query)
     sessions = result.scalars().all()

--- a/fapi/utils/session_utils.py
+++ b/fapi/utils/session_utils.py
@@ -1,3 +1,4 @@
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from fapi.db import models, schemas
 from fapi.core.cache import cache_result, invalidate_cache


### PR DESCRIPTION
This PR fixes a backend filtering issue in resources -> recording -> session where recent Misc sessions were not appearing for the ML course.
What changed:
Added a minimal special case for Misc in fetch_sessions_by_type_orm()
removed course_subject join/filter only for Misc
kept the existing ML date filter intact
left all non-Misc session types unchanged