### PR TITLE
Fixed the timestamps of updated_at and created_at columns in automation contact update

### DIFF
--- a/fapi/api/routes/automation_contact_extract.py
+++ b/fapi/api/routes/automation_contact_extract.py
@@ -4,8 +4,8 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 from fapi.db.database import get_db
 from fapi.db.schemas import (
-    AutomationContactExtractCreate, 
-    AutomationContactExtractUpdate, 
+    AutomationContactExtractCreate,
+    AutomationContactExtractUpdate,
     AutomationContactExtractOut,
     AutomationContactExtractBulkCreate,
     AutomationContactExtractBulkResponse,
@@ -19,6 +19,7 @@ router = APIRouter(tags=["Automation Extracts"])
 
 security = HTTPBearer()
 
+
 @router.head("/automation-extracts")
 @router.head("/automation-extracts/paginated")
 def check_version(
@@ -26,6 +27,7 @@ def check_version(
     credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     return get_automation_extracts_version(db)
+
 
 @router.get("/automation-extracts", response_model=List[AutomationContactExtractOut])
 async def read_automation_extracts(
@@ -38,11 +40,12 @@ async def read_automation_extracts(
     unsubscribed_flag: Optional[bool] = None,
     complained_flag: Optional[bool] = None,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     return await automation_contact_utils.get_all_automation_extracts(
         db, status=status, source_email=source_email
     )
+
 
 @router.get("/automation-extracts/paginated")
 def read_automation_extracts_paginated(
@@ -56,7 +59,7 @@ def read_automation_extracts_paginated(
     unsubscribed_flag: Optional[bool] = None,
     complained_flag: Optional[bool] = None,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     """Get automation extracts with page-based pagination and optional filters"""
     page_size = min(max(1, page_size), 10000)
@@ -72,7 +75,9 @@ def read_automation_extracts_paginated(
         complained_flag=complained_flag,
     )
     total_records = automation_contact_utils.count_automation_extracts(db, **filters)
-    data = automation_contact_utils.get_automation_extracts_paginated(db, skip=skip, limit=page_size, **filters)
+    data = automation_contact_utils.get_automation_extracts_paginated(
+        db, skip=skip, limit=page_size, **filters
+    )
     total_pages = max(1, (total_records + page_size - 1) // page_size)
     return {
         "data": data,
@@ -81,55 +86,79 @@ def read_automation_extracts_paginated(
         "total_records": total_records,
         "total_pages": total_pages,
         "has_next": page < total_pages,
-        "has_prev": page > 1
+        "has_prev": page > 1,
     }
 
-@router.post("/automation-extracts", response_model=AutomationContactExtractOut, status_code=status.HTTP_201_CREATED)
+
+@router.post(
+    "/automation-extracts",
+    response_model=AutomationContactExtractOut,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_automation_extract(
-    extract: AutomationContactExtractCreate, 
+    extract: AutomationContactExtractCreate,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     return await automation_contact_utils.insert_automation_extract(extract, db)
 
-@router.post("/automation-extracts/bulk", response_model=AutomationContactExtractBulkResponse)
+
+@router.post(
+    "/automation-extracts/bulk", response_model=AutomationContactExtractBulkResponse
+)
 async def create_automation_extracts_bulk(
     bulk_data: AutomationContactExtractBulkCreate,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
-    return await automation_contact_utils.insert_automation_extracts_bulk(bulk_data.extracts, db)
+    return await automation_contact_utils.insert_automation_extracts_bulk(
+        bulk_data.extracts, db
+    )
+
 
 @router.delete("/automation-extracts/bulk", status_code=status.HTTP_200_OK)
 async def delete_automation_extracts_bulk(
-    extract_ids: List[int] = Body(...), 
+    extract_ids: List[int] = Body(...),
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
-    return await automation_contact_utils.delete_automation_extracts_bulk(extract_ids, db)
+    return await automation_contact_utils.delete_automation_extracts_bulk(
+        extract_ids, db
+    )
 
-@router.get("/automation-extracts/{extract_id}", response_model=AutomationContactExtractOut)
+
+@router.get(
+    "/automation-extracts/{extract_id}", response_model=AutomationContactExtractOut
+)
 async def read_automation_extract(
-    extract_id: int, 
+    extract_id: int,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     return await automation_contact_utils.get_automation_extract_by_id(extract_id, db)
 
-@router.put("/automation-extracts/{extract_id}", response_model=AutomationContactExtractOut)
-async def update_automation_extract(
-    extract_id: int, 
-    update_data: AutomationContactExtractUpdate, 
-    db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
-):
-    return await automation_contact_utils.update_automation_extract(extract_id, update_data, db)
 
-@router.delete("/automation-extracts/{extract_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_automation_extract(
-    extract_id: int, 
+@router.put(
+    "/automation-extracts/{extract_id}", response_model=AutomationContactExtractOut
+)
+async def update_automation_extract(
+    extract_id: int,
+    update_data: AutomationContactExtractUpdate,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
+):
+    return await automation_contact_utils.update_automation_extract(
+        extract_id, update_data, db
+    )
+
+
+@router.delete(
+    "/automation-extracts/{extract_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_automation_extract(
+    extract_id: int,
+    db: Session = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     await automation_contact_utils.delete_automation_extract(extract_id, db)
     return None
@@ -139,11 +168,13 @@ async def delete_automation_extract(
 async def check_existing_emails(
     payload: CheckEmailsRequest,
     db: Session = Depends(get_db),
-    credentials: HTTPAuthorizationCredentials = Security(security)
+    credentials: HTTPAuthorizationCredentials = Security(security),
 ):
     """
     Check which of the provided emails already exist in automation_contact_extracts.
     Used for global deduplication before inserting.
     """
-    found = await automation_contact_utils.check_existing_emails_bulk(payload.emails, db)
+    found = await automation_contact_utils.check_existing_emails_bulk(
+        payload.emails, db
+    )
     return CheckEmailsResponse(existing_emails=found)

--- a/fapi/db/models.py
+++ b/fapi/db/models.py
@@ -1095,6 +1095,8 @@ class AutomationContactExtractORM(Base):
     mailbox_invalid = Column(Boolean, nullable=False, server_default='0')
 
     last_email_sent_at = Column(DateTime, nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
 
     bounced_flag = Column(Boolean, nullable=False, server_default='0')
     unsubscribed_flag = Column(Boolean, nullable=False, server_default='0')
@@ -1105,10 +1107,9 @@ class AutomationContactExtractORM(Base):
     complained_at = Column(DateTime, nullable=True)
 
     # Timestamps
-    created_at = Column(TIMESTAMP, server_default=func.now())
-    processed_at = Column(TIMESTAMP, nullable=True)
-    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
 
+    processed_at = Column(TIMESTAMP, nullable=True)
+    
     __table_args__ = (
         UniqueConstraint('email_key', 'linkedin_key', name='uq_email_linkedin'),
         Index('idx_status', 'processing_status'),

--- a/fapi/db/schemas.py
+++ b/fapi/db/schemas.py
@@ -176,7 +176,7 @@ class AutomationContactExtractBulkCreate(BaseModel):
 class AutomationContactExtractBulkResponse(BaseModel):
     total: int
     inserted: int
-    duplicates: int
+    updated: int
     failed: int
     errors: List[Dict[str, Any]] = []
 

--- a/fapi/utils/automation_contact_utils.py
+++ b/fapi/utils/automation_contact_utils.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Optional, Dict, Any
+from datetime import datetime
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from fastapi import HTTPException, Response
@@ -8,9 +9,9 @@ from fapi.utils.table_fingerprint import generate_version_for_model
 
 from fapi.db.models import AutomationContactExtractORM
 from fapi.db.schemas import (
-    AutomationContactExtractCreate, 
+    AutomationContactExtractCreate,
     AutomationContactExtractUpdate,
-    ContactProcessingStatusEnum
+    ContactProcessingStatusEnum,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,13 +24,20 @@ async def get_all_automation_extracts(db: Session, status: Optional[str] = None,
     try:
         query = db.query(AutomationContactExtractORM)
         if status:
-            query = query.filter(AutomationContactExtractORM.processing_status == status)
+            query = query.filter(
+                AutomationContactExtractORM.processing_status == status
+            )
         if source_email:
-            query = query.filter(AutomationContactExtractORM.source_reference == source_email)
+            query = query.filter(
+                AutomationContactExtractORM.source_reference == source_email
+            )
         return query.order_by(AutomationContactExtractORM.id.desc()).all()
     except SQLAlchemyError as e:
         logger.error(f"Error fetching automation extracts: {str(e)}")
-        raise HTTPException(status_code=500, detail="Error fetching automation extracts")
+        raise HTTPException(
+            status_code=500, detail="Error fetching automation extracts"
+        )
+
 
 @cache_result(ttl=300, prefix="automation_contacts")
 def count_automation_extracts(
@@ -45,25 +53,38 @@ def count_automation_extracts(
     try:
         query = db.query(AutomationContactExtractORM)
         if status:
-            query = query.filter(AutomationContactExtractORM.processing_status == status)
+            query = query.filter(
+                AutomationContactExtractORM.processing_status == status
+            )
         if email_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.email_invalid == email_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.email_invalid == email_invalid
+            )
         if domain_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.domain_invalid == domain_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.domain_invalid == domain_invalid
+            )
         if mailbox_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.mailbox_invalid == mailbox_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.mailbox_invalid == mailbox_invalid
+            )
         if bounced_flag is not None:
-            query = query.filter(AutomationContactExtractORM.bounced_flag == bounced_flag)
+            query = query.filter(
+                AutomationContactExtractORM.bounced_flag == bounced_flag
+            )
         if unsubscribed_flag is not None:
-            query = query.filter(AutomationContactExtractORM.unsubscribed_flag == unsubscribed_flag)
+            query = query.filter(
+                AutomationContactExtractORM.unsubscribed_flag == unsubscribed_flag
+            )
         if complained_flag is not None:
-            query = query.filter(AutomationContactExtractORM.complained_flag == complained_flag)
+            query = query.filter(
+                AutomationContactExtractORM.complained_flag == complained_flag
+            )
         return query.count()
     except SQLAlchemyError as e:
         logger.error(f"Error counting automation extracts: {str(e)}")
         raise HTTPException(status_code=500, detail=f"DB Error: {str(e)}")
 
-@cache_result(ttl=300, prefix="automation_contacts")
 def get_automation_extracts_paginated(
     db: Session,
     skip: int = 0,
@@ -79,23 +100,44 @@ def get_automation_extracts_paginated(
     try:
         query = db.query(AutomationContactExtractORM)
         if status:
-            query = query.filter(AutomationContactExtractORM.processing_status == status)
+            query = query.filter(
+                AutomationContactExtractORM.processing_status == status
+            )
         if email_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.email_invalid == email_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.email_invalid == email_invalid
+            )
         if domain_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.domain_invalid == domain_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.domain_invalid == domain_invalid
+            )
         if mailbox_invalid is not None:
-            query = query.filter(AutomationContactExtractORM.mailbox_invalid == mailbox_invalid)
+            query = query.filter(
+                AutomationContactExtractORM.mailbox_invalid == mailbox_invalid
+            )
         if bounced_flag is not None:
-            query = query.filter(AutomationContactExtractORM.bounced_flag == bounced_flag)
+            query = query.filter(
+                AutomationContactExtractORM.bounced_flag == bounced_flag
+            )
         if unsubscribed_flag is not None:
-            query = query.filter(AutomationContactExtractORM.unsubscribed_flag == unsubscribed_flag)
+            query = query.filter(
+                AutomationContactExtractORM.unsubscribed_flag == unsubscribed_flag
+            )
         if complained_flag is not None:
-            query = query.filter(AutomationContactExtractORM.complained_flag == complained_flag)
-        return query.order_by(AutomationContactExtractORM.id.desc()).offset(skip).limit(limit).all()
+            query = query.filter(
+                AutomationContactExtractORM.complained_flag == complained_flag
+            )
+        return (
+            query.order_by(AutomationContactExtractORM.id.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
     except SQLAlchemyError as e:
         logger.error(f"Error fetching paginated automation extracts: {str(e)}")
-        raise HTTPException(status_code=500, detail="Error fetching paginated automation extracts")
+        raise HTTPException(
+            status_code=500, detail="Error fetching paginated automation extracts"
+        )
 
 @cache_result(ttl=300, prefix="automation_contacts")
 async def get_automation_extract_by_id(extract_id: int, db: Session) -> AutomationContactExtractORM:
@@ -104,19 +146,43 @@ async def get_automation_extract_by_id(extract_id: int, db: Session) -> Automati
         raise HTTPException(status_code=404, detail="Automation extract not found")
     return extract
 
-async def insert_automation_extract(extract: AutomationContactExtractCreate, db: Session) -> AutomationContactExtractORM:
+
+async def insert_automation_extract(
+    extract: AutomationContactExtractCreate, db: Session
+) -> AutomationContactExtractORM: 
     invalidate_cache("automation_contacts")
     try:
-        data = {k: v for k, v in extract.dict().items() if k not in _COMPUTED_COLS}
-        db_extract = AutomationContactExtractORM(**data)
-        db.add(db_extract)
-        db.commit()
-        db.refresh(db_extract)
-        return db_extract
+        current_time = datetime.utcnow()
+        existing = (
+            db.query(AutomationContactExtractORM)
+            .filter(
+                AutomationContactExtractORM.email_lc == extract.email.strip().lower()
+            )
+            .first()
+        )
+
+        if existing:
+            # updating created at and updated at
+            existing.created_at = current_time
+            existing.updated_at = current_time
+            db.commit()
+            db.refresh(existing)
+            return existing
+        else:
+            # if new record
+            data = {k: v for k, v in extract.dict().items() if k not in _COMPUTED_COLS}
+            db_extract = AutomationContactExtractORM(
+                **data, created_at=current_time, updated_at=current_time
+            )
+            db.add(db_extract)
+            db.commit()
+            db.refresh(db_extract)
+            return db_extract
     except Exception as e:
         db.rollback()
-        logger.error(f"Insert error: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Insert error: {str(e)}")
+        logger.error(f"upsert error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"upsert error: {str(e)}")
+   
 
 async def update_automation_extract(extract_id: int, update_data: AutomationContactExtractUpdate, db: Session) -> AutomationContactExtractORM:
     invalidate_cache("automation_contacts")
@@ -125,7 +191,7 @@ async def update_automation_extract(extract_id: int, update_data: AutomationCont
         update_fields = update_data.dict(exclude_unset=True)
         for field, value in update_fields.items():
             setattr(db_extract, field, value)
-        
+
         db.commit()
         db.refresh(db_extract)
         return db_extract
@@ -133,6 +199,7 @@ async def update_automation_extract(extract_id: int, update_data: AutomationCont
         db.rollback()
         logger.error(f"Update error: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Update error: {str(e)}")
+
 
 async def delete_automation_extract(extract_id: int, db: Session) -> dict:
     invalidate_cache("automation_contacts")
@@ -146,45 +213,75 @@ async def delete_automation_extract(extract_id: int, db: Session) -> dict:
         logger.error(f"Delete error: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Delete error: {str(e)}")
 
-async def insert_automation_extracts_bulk(extracts: List[AutomationContactExtractCreate], db: Session) -> dict:
+async def insert_automation_extracts_bulk(
+    extracts: List[AutomationContactExtractCreate], 
+    db: Session
+) -> dict:
     invalidate_cache("automation_contacts")
+    extraction_time = datetime.utcnow()  # capturing the time of extraction
     inserted = 0
+    updated = 0  # new counter for updated records
     failed = 0
-    duplicates = 0
-    errors = []
-    
+    errors=[]
+
     for ext in extracts:
         try:
             with db.begin_nested():
-                data = {k: v for k, v in ext.dict().items() if k not in _COMPUTED_COLS}
-                db_extract = AutomationContactExtractORM(**data)
-                db.add(db_extract)
+                # check if email already registered or not
+                existing = (
+                    db.query(AutomationContactExtractORM)
+                    .filter(
+                        AutomationContactExtractORM.email_lc
+                        == ext.email.strip().lower()
+                        if ext.email
+                        else None
+                    )
+                    .first()
+                )
+                if existing:
+                    # update updated_at to extraction time
+                    existing.updated_at = extraction_time
+                    existing.created_at = extraction_time
+                    updated += 1
+                else:
+                    # will insert if the email is new
+                    data = {
+                        k: v for k, v in ext.dict().items() if k not in _COMPUTED_COLS
+                    }
+                    db_extract = AutomationContactExtractORM(**data,created_at=extraction_time, updated_at=extraction_time)
+                    db.add(db_extract)
+                    inserted += 1
                 db.flush()
-            inserted += 1
-        except IntegrityError:
-            duplicates += 1
         except Exception as e:
             failed += 1
-            errors.append({"full_name": ext.full_name, "email": ext.email, "error": str(e)})
+            errors.append(
+                {"full_name": ext.full_name, "email": ext.email, "error": str(e)}
+            )
             logger.error(f"Failed to insert extract {ext.full_name}: {str(e)}")
-            
+
     db.commit()
     return {
         "total": len(extracts),
         "inserted": inserted,
-        "duplicates": duplicates,
+        "updated": updated,  # including the updated count here
         "failed": failed,
-        "errors": errors
+        "errors": errors,
     }
+
 
 async def delete_automation_extracts_bulk(extract_ids: List[int], db: Session) -> dict:
     invalidate_cache("automation_contacts")
     try:
-        deleted_count = db.query(AutomationContactExtractORM).filter(
-            AutomationContactExtractORM.id.in_(extract_ids)
-        ).delete(synchronize_session=False)
+        deleted_count = (
+            db.query(AutomationContactExtractORM)
+            .filter(AutomationContactExtractORM.id.in_(extract_ids))
+            .delete(synchronize_session=False)
+        )
         db.commit()
-        return {"deleted": deleted_count, "message": f"Successfully deleted {deleted_count} extracts"}
+        return {
+            "deleted": deleted_count,
+            "message": f"Successfully deleted {deleted_count} extracts",
+        }
     except Exception as e:
         db.rollback()
         logger.error(f"Bulk delete error: {str(e)}")
@@ -206,6 +303,7 @@ async def check_existing_emails_bulk(emails: List[str], db: Session) -> List[str
     except Exception as e:
         logger.error(f"Bulk email check failed: {str(e)}")
         raise HTTPException(status_code=500, detail="Bulk email check failed")
+
 
 def get_automation_extracts_version(db: Session) -> Response:
     return generate_version_for_model(db, AutomationContactExtractORM)

--- a/fapi/utils/automation_contact_utils.py
+++ b/fapi/utils/automation_contact_utils.py
@@ -31,7 +31,7 @@ async def get_all_automation_extracts(db: Session, status: Optional[str] = None,
             query = query.filter(
                 AutomationContactExtractORM.source_reference == source_email
             )
-        return query.order_by(AutomationContactExtractORM.id.desc()).all()
+        return query.order_by(AutomationContactExtractORM.updated_at.desc()).all()
     except SQLAlchemyError as e:
         logger.error(f"Error fetching automation extracts: {str(e)}")
         raise HTTPException(
@@ -128,7 +128,7 @@ def get_automation_extracts_paginated(
                 AutomationContactExtractORM.complained_flag == complained_flag
             )
         return (
-            query.order_by(AutomationContactExtractORM.id.desc())
+            query.order_by(AutomationContactExtractORM.updated_at.desc())
             .offset(skip)
             .limit(limit)
             .all()


### PR DESCRIPTION
When a Duplicate mail is re-entered into the table, the created_at and updated_at column Values are set to the time of extraction.