### PR TITLE
Add Jobright to allowed sources and orchestrator workflows

### DIFF
--- a/fapi/db/schemas.py
+++ b/fapi/db/schemas.py
@@ -37,6 +37,7 @@ class JobListingSourceEnum(str, enum.Enum):
     job_board = 'job_board'
     scraper = 'scraper'
     hiring_cafe = 'hiring.cafe'
+    jobright_ai = 'jobright.ai'
     trueup_io = 'trueup.io'
     interview_modal = 'interview_modal'
     email_bot_llm_local = 'email_bot_llm_local'

--- a/fapi/utils/outreach_orchestrator_utils.py
+++ b/fapi/utils/outreach_orchestrator_utils.py
@@ -65,6 +65,7 @@ _ALLOWED_WORKFLOW_KEYS = {
     "weekly_potential_leads_outreach",
     "linkedin_non_easy_job_extractor",
     "hiring_cafe_job_extractor",
+    "jobright-engine",
     "weekly_marketing_report",
 }
 


### PR DESCRIPTION
Overview
This PR adds support for the `jobright-engine` automated ingestion pipeline, allowing Jobright payload data to be successfully parsed and scheduled by the orchestrator.

Changes Made
fapi/db/schemas.py : Added `jobright.ai` to the `JobListingSourceEnum` to prevent Pydantic validation errors during data ingestion.

fapi/utils/outreach_orchestrator_utils.py : Whitelisted `"jobright-engine"` in the `_ALLOWED_WORKFLOW_KEYS` list so that the backend orchestrator successfully surfaces Jobright pipeline schedules to the polling engine.