### PR TITLE
Dev

### DIFF
--- a/fapi/api/routes/coderpad.py
+++ b/fapi/api/routes/coderpad.py
@@ -17,10 +17,12 @@ from fapi.db.schemas import (
     CoderpadAssignableCandidateOut,
     CoderpadLlmValidateRequest,
     CoderpadLlmValidateResponse,
+    CoderpadLlmGenerateRequest,
+    CoderpadLlmGenerateResponse,
 )
 from fapi.utils.auth_dependencies import get_current_user, staff_or_admin_required
 from fapi.utils import coderpad_utils
-from fapi.utils.coderpad_llm_utils import llm_validate_code_submission
+from fapi.utils.coderpad_llm_utils import llm_validate_code_submission, llm_generate_question_from_topic
 import logging
 import os
 
@@ -129,13 +131,35 @@ def llm_validate_coderpad(
     body: CoderpadLlmValidateRequest,
     x_openai_api_key: Optional[str] = Header(None, alias="X-OpenAI-Api-Key"),
     current_user: AuthUserORM = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """
     Validate candidate code against the problem + test cases using OpenAI.
-    Key resolution: optional X-OpenAI-Api-Key header, else server env
-    CODERPAD_OPENAI_API_KEY or OPENAI_API_KEY (not persisted in DB yet).
+    Key resolution: checks CandidateAPIKeyORM first for candidates, then optional 
+    X-OpenAI-Api-Key header, else server env CODERPAD_OPENAI_API_KEY or OPENAI_API_KEY.
     """
     key = _resolve_openai_api_key(x_openai_api_key)
+
+    is_admin = (
+        getattr(current_user, "role", None) == "admin"
+        or getattr(current_user, "is_admin", False)
+        or getattr(current_user, "is_employee", False)
+        or (getattr(current_user, "uname", "") or "").lower() == "admin"
+    )
+
+    if not is_admin:
+        from fapi.utils.db_queries import fetch_candidate_id_and_status_by_email
+        from fapi.db.models import CandidateAPIKeyORM
+        candidate_info = fetch_candidate_id_and_status_by_email(db, current_user.uname)
+        if candidate_info:
+            cid = candidate_info.candidateid
+            api_key_record = db.query(CandidateAPIKeyORM).filter(
+                CandidateAPIKeyORM.candidate_id == cid,
+                CandidateAPIKeyORM.provider_name.ilike("%openai%")
+            ).first()
+            if api_key_record and api_key_record.api_key:
+                key = api_key_record.api_key
+
     if not key:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -156,6 +180,44 @@ def llm_validate_coderpad(
         model=model,
     )
     return CoderpadLlmValidateResponse(**result)
+
+
+@router.post("/llm-generate", response_model=CoderpadLlmGenerateResponse)
+def llm_generate_question(
+    body: CoderpadLlmGenerateRequest,
+    x_openai_api_key: Optional[str] = Header(None, alias="X-OpenAI-Api-Key"),
+    current_user: AuthUserORM = Depends(staff_or_admin_required),
+):
+    """
+    Generate a CoderPad question (title, statement, starter code, test cases) from a topic.
+    """
+    key = _resolve_openai_api_key(x_openai_api_key)
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="OpenAI API key not configured: set CODERPAD_OPENAI_API_KEY or OPENAI_API_KEY on the server, or send X-OpenAI-Api-Key",
+        )
+    if not (body.topic or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="topic is required",
+        )
+
+    model = (body.model or "gpt-4o-mini").strip()
+    result = llm_generate_question_from_topic(
+        topic=body.topic.strip(),
+        language=body.language or "python",
+        openai_api_key=key,
+        model=model,
+    )
+
+    if result.get("error"):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result["error"]
+        )
+
+    return CoderpadLlmGenerateResponse(**result)
 
 
 @router.post("/snippets/{snippet_id}/execute", response_model=CodeExecutionWithTestsResponse)

--- a/fapi/db/schemas.py
+++ b/fapi/db/schemas.py
@@ -4169,6 +4169,21 @@ class CoderpadLlmValidateResponse(BaseModel):
     error: Optional[str] = None
 
 
+class CoderpadLlmGenerateRequest(BaseModel):
+    topic: str
+    language: Optional[str] = "python"
+    model: Optional[str] = "gpt-4o-mini"
+
+
+class CoderpadLlmGenerateResponse(BaseModel):
+    title: str = ""
+    problem_statement: str = ""
+    starter_code: str = ""
+    language: str = "python"
+    test_cases: Optional[List[TestCase]] = None
+    error: Optional[str] = None
+
+
 class CodeExecutionLogOut(BaseModel):
     id: int
     code_snippet_id: Optional[int] = None  # None for direct executions (no saved snippet)

--- a/fapi/utils/coderpad_llm_utils.py
+++ b/fapi/utils/coderpad_llm_utils.py
@@ -164,3 +164,77 @@ def llm_validate_code_submission(
         "raw_model_text": content,
         "error": None,
     }
+
+
+CODERPAD_GENERATE_SYSTEM_PROMPT = (
+    "You are an expert programming assignment creator. "
+    "Given a topic, generate a complete coding problem with a description, starter code, and test cases. "
+    "Output MUST be pure JSON with no markdown fences, matching the requested schema."
+)
+
+def llm_generate_question_from_topic(
+    *,
+    topic: str,
+    language: str = "python",
+    openai_api_key: str,
+    model: str = DEFAULT_MODEL,
+) -> Dict[str, Any]:
+    key = (openai_api_key or "").strip()
+    if not key:
+        return {"error": "OpenAI API key is required"}
+    
+    user_prompt = f"""Generate a coding problem based on the following topic: "{topic}".
+The target programming language is {language}.
+
+Format requirements for `problem_statement`:
+- Use rich HTML formatting in the style of LeetCode or HackerRank.
+- Start with a clear problem description wrapped in appropriate <p> tags.
+- Include an "Examples" section with at least two examples (Input, Output, and Explanation). Use <pre> or <code> blocks and <strong> text for clarity.
+- Include a "Constraints" section (e.g., as a <ul> list).
+- Ensure the formatting uses proper spacing and alignment, utilizing HTML tags.
+
+Output EXACTLY this JSON format and no accompanying text:
+{{
+  "title": "<A concise title for the assignment>",
+  "problem_statement": "<The richly formatted HTML string containing the description, examples, and constraints.>",
+  "starter_code": "<Initial code template for the candidate to start with. Should include function signature.>",
+  "language": "{language}",
+  "test_cases": [
+    {{
+      "input": "<string of input, or empty if args are passed in code directly>",
+      "expected_output": "<string of expected output when the function is run>",
+      "description": "<short description of what this tests>",
+      "locked": false
+    }}
+  ]
+}}
+Ensure you generate 3 to 5 test cases. Ensure starter_code has necessary imports and a working function signature.
+"""
+
+    result = openai_chat_with_prompts(
+        system_prompt=CODERPAD_GENERATE_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        api_key=key,
+        model=model,
+        temperature=0.3,
+        max_tokens=3000,
+        timeout=90.0,
+    )
+
+    if result.error:
+        return {"error": result.error}
+
+    content = result.content or ""
+    parsed = _parse_json_from_text(content)
+    if not parsed:
+        return {"error": "Could not parse model output as JSON. Output was: " + content[:200]}
+
+    return {
+        "title": parsed.get("title", ""),
+        "problem_statement": parsed.get("problem_statement", ""),
+        "starter_code": parsed.get("starter_code", ""),
+        "language": parsed.get("language", language),
+        "test_cases": parsed.get("test_cases", []),
+        "error": None,
+    }
+


### PR DESCRIPTION
Candidate API Key Routing & HTML Generation Support
AI prompt engine for generating problem statements

Candidate-Specific API Key Resolution: Refactored the /llm-validate endpoint to accept a database session dependency. The system now detects if the requesting user is a candidate. If so, it queries the candidate_api_keys table for an OpenAI provider key. If a personal key is found, it automatically overrides the system's global API key. Admins and staff natively bypass this check.
HTML Prompt Engineering: Updated the system prompt inside llm_generate_question_from_topic (coderpad_llm_utils.py). The LLM is now strictly instructed to generate problem statements in rich HTML format (using, , and  tags) rather than markdown, seamlessly supporting the new WYSIWYG frontend editor.
Schema Additions: Officially registered the CoderpadLlmGenerateRequest and CoderpadLlmGenerateResponse models inside schemas.py to type-validate the AI assignment generation route.