### PR TITLE
fix(session): return all sessions by default when no size is provided

### DIFF
--- a/fapi/api/routes/session.py
+++ b/fapi/api/routes/session.py
@@ -7,11 +7,18 @@ from fapi.db.database import get_db
 router = APIRouter()
 
 
+# @router.get("/session", response_model=list[schemas.SessionOut])
+# def read_sessions(
+    # search_title: str = None,
+    # page: int = Query(default=1, ge=1),         
+    # size: int = Query(default=100, le=2000),      
+    # db: Session = Depends(get_db)
+# ):
 @router.get("/session", response_model=list[schemas.SessionOut])
 def read_sessions(
     search_title: str = None,
-    page: int = Query(default=1, ge=1),         
-    size: int = Query(default=100, le=2000),      
+    page: int = Query(default=1, ge=1),
+    size: int | None = Query(default=None),
     db: Session = Depends(get_db)
 ):
     return session_utils.get_sessions(

--- a/fapi/utils/session_utils.py
+++ b/fapi/utils/session_utils.py
@@ -5,7 +5,8 @@ from fapi.core.cache import cache_result, invalidate_cache
 
 
 @cache_result(ttl=300, prefix="sessions")
-def get_sessions(db: Session, search_title: str = None, page: int = 1, size: int = 200):
+# def get_sessions(db: Session, search_title: str = None, page: int = 1, size: int = 200):
+def get_sessions(db: Session, search_title: str = None, page: int = 1, size: int | None = None):
     query = db.query(models.Session)
 
     if search_title:
@@ -16,9 +17,12 @@ def get_sessions(db: Session, search_title: str = None, page: int = 1, size: int
 
     # pagination FIX
     query = query.order_by(models.Session.sessionid.desc())
-    query = query.offset((page - 1) * size).limit(size)
+    if size is not None:
+        query = query.offset((page - 1) * size).limit(size)
+    # query = query.offset((page - 1) * size).limit(size)
 
     return query.all()
+    
 
 
 # =========================

--- a/tests/contract/snapshots/openapi_snapshot.json
+++ b/tests/contract/snapshots/openapi_snapshot.json
@@ -5022,9 +5022,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "maximum": 2000,
-              "default": 100,
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Size"
             }
           }
@@ -45989,6 +45994,17 @@
               }
             ],
             "title": "Login Count"
+          },
+          "candidate_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Candidate Id"
           }
         },
         "type": "object",


### PR DESCRIPTION
Updated **the Session API to return all sessions by default** when no size parameter is provided. Existing pagination behavior remains unchanged when size is specified.