### PR TITLE
 candidate transition state flags and deactivation on candidate closed status

### DIFF
--- a/fapi/utils/candidate_utils.py
+++ b/fapi/utils/candidate_utils.py
@@ -166,6 +166,29 @@ def update_candidate(candidate_id: int, candidate_data: dict):
 
         db.flush()
 
+        # If candidate status is updated to closed, deactivate active prep, marketing, and placement records
+        if candidate.status and str(candidate.status).lower() == "closed":
+            # Deactivate active prep
+            active_preps = db.query(CandidatePreparation).filter_by(candidate_id=candidate.id, status='active').all()
+            for prep in active_preps:
+                prep.status = "inactive"
+                prep.move_to_mrkt = False
+            
+            # Deactivate active marketing
+            active_marketings = db.query(CandidateMarketingORM).filter_by(candidate_id=candidate.id, status='active').all()
+            for marketing in active_marketings:
+                marketing.status = "inactive"
+                marketing.move_to_placement = False
+
+            # Deactivate active placement
+            active_placements = db.query(CandidatePlacementORM).filter_by(candidate_id=candidate.id, status='Active').all()
+            for placement in active_placements:
+                placement.status = "Inactive"
+
+            # Set candidate move_to_prep flag to False
+            candidate.move_to_prep = False
+            db.flush()
+
 
         if getattr(candidate, "move_to_prep", False):
             active_prep = db.query(CandidatePreparation).filter_by(candidate_id=candidate.id, status='active').first()
@@ -176,6 +199,11 @@ def update_candidate(candidate_id: int, candidate_data: dict):
                     status="active"
                 )
                 db.add(new_prep)
+        else:
+            active_prep = db.query(CandidatePreparation).filter_by(candidate_id=candidate.id, status='active').first()
+            if active_prep:
+                active_prep.status = "inactive"
+                db.flush()
         
         # Keep the flag in sync with the actual active preparation status
         final_active_prep = db.query(CandidatePreparation).filter_by(candidate_id=candidate.id, status='active').first()
@@ -424,6 +452,11 @@ def update_marketing(record_id: int, payload: CandidateMarketingUpdate) -> dict:
                         status="Active"
                     )
                     db.add(new_placement)
+        else:
+            active_placement = db.query(CandidatePlacementORM).filter_by(candidate_id=record.candidate_id, status="Active").first()
+            if active_placement:
+                active_placement.status = "Inactive"
+                db.flush()
 
         # Keep flag in sync with actual active placement status
         final_placement = db.query(CandidatePlacementORM).filter_by(candidate_id=record.candidate_id, status="Active").first()
@@ -1073,6 +1106,11 @@ def update_candidate_preparation(db: Session, prep_id: int, updates: CandidatePr
                 status="active"
             )
             db.add(new_marketing)
+    else:
+        active_marketing = db.query(CandidateMarketingORM).filter_by(candidate_id=db_prep.candidate_id, status="active").first()
+        if active_marketing:
+            active_marketing.status = "inactive"
+            db.flush()
 
     # Keep flag in sync with actual active marketing status
     final_marketing = db.query(CandidateMarketingORM).filter_by(candidate_id=db_prep.candidate_id, status="active").first()

--- a/tests/integration/test_transitions.py
+++ b/tests/integration/test_transitions.py
@@ -1,0 +1,201 @@
+import pytest
+from datetime import date
+from fapi.db.models import CandidateORM, CandidatePreparation, CandidateMarketingORM, CandidatePlacementORM
+from fapi.db.schemas import CandidatePreparationUpdate, CandidateMarketingUpdate
+from fapi.utils.candidate_utils import update_candidate_preparation, update_marketing, update_candidate
+
+def test_transition_prep_to_marketing(db_session):
+    # 1. Create a candidate
+    candidate = CandidateORM(
+        full_name="Transition Test Candidate",
+        email="transition@test.com",
+        status="active",
+        phone="555-1234",
+        batchid=1
+    )
+    db_session.add(candidate)
+    db_session.commit()
+    db_session.refresh(candidate)
+
+    # 2. Create CandidatePreparation with move_to_mrkt=True
+    prep = CandidatePreparation(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active",
+        move_to_mrkt=True
+    )
+    db_session.add(prep)
+    db_session.commit()
+    db_session.refresh(prep)
+
+    # Manually ensure CandidateMarketingORM exists as it would be created during flow
+    marketing = CandidateMarketingORM(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active"
+    )
+    db_session.add(marketing)
+    db_session.commit()
+
+    # Now verify the flag is True
+    assert prep.move_to_mrkt is True
+
+    # 3. Call update_candidate_preparation with move_to_mrkt=False
+    updates = CandidatePreparationUpdate(move_to_mrkt=False)
+    updated_prep = update_candidate_preparation(db_session, prep.id, updates)
+
+    # 4. Verify candidate marketing status is inactive
+    db_session.refresh(marketing)
+    assert marketing.status == "inactive"
+    assert updated_prep.move_to_mrkt is False
+
+def test_transition_marketing_to_placement(db_session):
+    # 1. Create candidate
+    candidate = CandidateORM(
+        full_name="Transition Test Candidate 2",
+        email="transition2@test.com",
+        status="active",
+        phone="555-5678",
+        batchid=1
+    )
+    db_session.add(candidate)
+    db_session.commit()
+    db_session.refresh(candidate)
+
+    # 2. Create CandidateMarketing with move_to_placement=True
+    marketing = CandidateMarketingORM(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active",
+        move_to_placement=True
+    )
+    db_session.add(marketing)
+    db_session.commit()
+    db_session.refresh(marketing)
+
+    # Create active Placement
+    placement = CandidatePlacementORM(
+        candidate_id=candidate.id,
+        company="Test Corp",
+        placement_date=date.today(),
+        status="Active"
+    )
+    db_session.add(placement)
+    db_session.commit()
+
+    assert marketing.move_to_placement is True
+
+    # 3. Call update_marketing with move_to_placement=False
+    payload = CandidateMarketingUpdate(move_to_placement=False)
+    updated_mkt = update_marketing(marketing.id, payload)
+
+    # 4. Verify placement status is Inactive
+    db_session.refresh(placement)
+    assert placement.status == "Inactive"
+    
+    # Reload marketing via SessionLocal (since update_marketing creates its own session)
+    updated_mkt_db = db_session.query(CandidateMarketingORM).filter(CandidateMarketingORM.id == marketing.id).first()
+    db_session.refresh(updated_mkt_db)
+    assert updated_mkt_db.move_to_placement is False
+
+def test_transition_candidate_to_prep(db_session):
+    # 1. Create candidate with move_to_prep=True
+    candidate = CandidateORM(
+        full_name="Transition Test Candidate 3",
+        email="transition3@test.com",
+        status="active",
+        phone="555-8888",
+        batchid=1,
+        move_to_prep=True
+    )
+    db_session.add(candidate)
+    db_session.commit()
+    db_session.refresh(candidate)
+
+    # Create active preparation
+    prep = CandidatePreparation(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active"
+    )
+    db_session.add(prep)
+    db_session.commit()
+
+    assert candidate.move_to_prep is True
+
+    # 2. Update candidate with move_to_prep=False
+    update_candidate(candidate.id, {"move_to_prep": False})
+
+    # 3. Verify prep status is inactive
+    db_session.refresh(prep)
+    assert prep.status == "inactive"
+
+    db_session.refresh(candidate)
+    assert candidate.move_to_prep is False
+
+def test_transition_candidate_closed(db_session):
+    # 1. Create a candidate
+    candidate = CandidateORM(
+        full_name="Transition Test Candidate 4",
+        email="transition4@test.com",
+        status="active",
+        phone="555-9999",
+        batchid=1,
+        move_to_prep=True
+    )
+    db_session.add(candidate)
+    db_session.commit()
+    db_session.refresh(candidate)
+
+    # 2. Create active prep, marketing, and placement records
+    prep = CandidatePreparation(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active",
+        move_to_mrkt=True
+    )
+    db_session.add(prep)
+    
+    marketing = CandidateMarketingORM(
+        candidate_id=candidate.id,
+        start_date=date.today(),
+        status="active",
+        move_to_placement=True
+    )
+    db_session.add(marketing)
+
+    placement = CandidatePlacementORM(
+        candidate_id=candidate.id,
+        company="Closed test corp",
+        placement_date=date.today(),
+        status="Active"
+    )
+    db_session.add(placement)
+    
+    db_session.commit()
+
+    # Verify initial states
+    assert candidate.move_to_prep is True
+    assert prep.move_to_mrkt is True
+    assert marketing.move_to_placement is True
+    assert prep.status == "active"
+    assert marketing.status == "active"
+    assert placement.status == "Active"
+
+    # 3. Update candidate status to "closed"
+    update_candidate(candidate.id, {"status": "closed"})
+
+    # 4. Verify all records deactivated and flags synchronized
+    db_session.refresh(candidate)
+    db_session.refresh(prep)
+    db_session.refresh(marketing)
+    db_session.refresh(placement)
+
+    assert candidate.status == "closed"
+    assert candidate.move_to_prep is False
+    assert prep.status == "inactive"
+    assert prep.move_to_mrkt is False
+    assert marketing.status == "inactive"
+    assert marketing.move_to_placement is False
+    assert placement.status == "Inactive"
+


### PR DESCRIPTION
Fixes candidate status transition bugs and implements automatic deactivation of active prep/marketing/placement records when a candidate is marked as `"closed"`.
Key Changes

* Deactivation Logic : Added status deactivation (`"inactive"` / `"Inactive"`) and flushes in [candidate_utils.py](file:///c:/Users/Innovapath/Desktop/checking/wbl-backend/fapi/utils/candidate_utils.py) when transition flags (`move_to_mrkt`, `move_to_placement`, `move_to_prep`) are toggled to `False`/`No`.
* Closed Candidates : Automatically deactivates all active prep, marketing, and placement records for a candidate when their status is set to `"closed"`.
* Tests : Added comprehensive unit/integration coverage in [test_transitions.py](file:///c:/Users/Innovapath/Desktop/checking/wbl-backend/tests/integration/test_transitions.py).