### PR TITLE
refactor: remove wboxcli_apply_analytics db table dependency

### DIFF
--- a/fapi/api/routes/cli_analytics.py
+++ b/fapi/api/routes/cli_analytics.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import Session
 
 from fapi.db.database import get_db
 from fapi.db.schemas import (
-    CliApplyRunBackfillResponse,
     CliApplyRunLatestOut,
     CliUsageEventBulkCreate,
     CliUsageEventBulkResponse,
@@ -103,16 +102,6 @@ def analytics_summary(
     _ = current_user
     return cli_analytics_utils.get_global_summary(db)
 
-
-@router.post("/apply-runs/backfill", response_model=CliApplyRunBackfillResponse)
-def backfill_apply_analytics(
-    limit: Optional[int] = Query(None, ge=1, le=100000),
-    db: Session = Depends(get_db),
-    current_user=Depends(staff_or_admin_required),
-):
-    """Staff: backfill wboxcli_apply_analytics from historical cli_usage_events."""
-    _ = current_user
-    return cli_analytics_utils.backfill_apply_analytics_from_events(db, limit=limit)
 
 
 @router.get("/users/{user_id}/applications/summary", response_model=CliUsageUserSummary)

--- a/fapi/db/models.py
+++ b/fapi/db/models.py
@@ -1789,21 +1789,6 @@ class CliUsageEventORM(Base):
         Index("idx_cli_usage_user_ts", "user_id", "event_ts"),
     )
 
-class WboxcliApplyAnalyticsORM(Base):
-    """One row per user — latest apply run (matches analytics AG Grid columns)."""
-
-    __tablename__ = "wboxcli_apply_analytics"
-
-    user_id = Column(String(255), primary_key=True)
-    jobs_attempted = Column(Integer, nullable=False, default=0)
-    jobs_submitted = Column(Integer, nullable=False, default=0)
-    jobs_failed = Column(Integer, nullable=False, default=0)
-    last_activity = Column(DateTime, nullable=False)
-    usage_event_id = Column(Integer, nullable=True)
-    result = Column(String(50), nullable=True)
-    updated_at = Column(TIMESTAMP, server_default=func.current_timestamp(), onupdate=func.current_timestamp())
-
-    __table_args__ = (Index("idx_wboxcli_apply_analytics_activity", "last_activity"),)
 
 # -------------------- Application Report (ATS CLI) --------------------
 class ApplicationReportORM(Base):

--- a/fapi/main.py
+++ b/fapi/main.py
@@ -51,7 +51,6 @@ async def startup_event():
         CodeExecutionLogORM,
         CoderpadQuestionORM,
         CliUsageEventORM,
-        WboxcliApplyAnalyticsORM,
         ApplicationReportORM
     )
     # Ensure all tables (including new columns) are created/updated
@@ -79,7 +78,6 @@ async def startup_event():
         CodeExecutionLogORM.__table__.create(bind=engine, checkfirst=True)
         CoderpadQuestionORM.__table__.create(bind=engine, checkfirst=True)
         CliUsageEventORM.__table__.create(bind=engine, checkfirst=True)
-        WboxcliApplyAnalyticsORM.__table__.create(bind=engine, checkfirst=True)
 
         # ATS Application Report Table
         ApplicationReportORM.__table__.create(bind=engine, checkfirst=True)

--- a/fapi/utils/candidate_dashboard_utils.py
+++ b/fapi/utils/candidate_dashboard_utils.py
@@ -1259,15 +1259,16 @@ def get_candidate_statistics(db: Session, candidate_id: int) -> Dict[str, Any]:
     # 4. Easy apply counter
     easy_apply_counter = 0
     if authuser:
-        from fapi.db.models import ApplicationReportORM, WboxcliApplyAnalyticsORM
+        from fapi.db.models import ApplicationReportORM, CliUsageEventORM
         autofill_count = db.query(func.count(ApplicationReportORM.id)).filter(
             ApplicationReportORM.user_id == authuser.id
         ).scalar() or 0
         
-        cli_analytics = db.query(WboxcliApplyAnalyticsORM).filter(
-            WboxcliApplyAnalyticsORM.user_id == authuser.uname
-        ).first()
-        cli_count = cli_analytics.jobs_submitted if cli_analytics else 0
+        latest_apply = db.query(CliUsageEventORM).filter(
+            CliUsageEventORM.user_id == authuser.uname,
+            CliUsageEventORM.command == "apply"
+        ).order_by(CliUsageEventORM.event_ts.desc()).first()
+        cli_count = latest_apply.jobs_submitted_count if latest_apply and latest_apply.jobs_submitted_count is not None else 0
         
         easy_apply_counter = autofill_count + cli_count
 

--- a/fapi/utils/cli_analytics_utils.py
+++ b/fapi/utils/cli_analytics_utils.py
@@ -10,7 +10,7 @@ from sqlalchemy import and_, func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from fapi.db.models import CliUsageEventORM, WboxcliApplyAnalyticsORM
+from fapi.db.models import CliUsageEventORM
 from fapi.db.schemas import (
     CliApplyRunJobOut,
     CliApplyRunLatestOut,
@@ -207,16 +207,9 @@ def get_latest_apply_run_for_user(db: Session, user_id: str) -> Optional[CliAppl
     if not uid:
         return None
 
-    event: Optional[CliUsageEventORM] = None
-    analytics = (
-        db.query(WboxcliApplyAnalyticsORM).filter(WboxcliApplyAnalyticsORM.user_id == uid).first()
+    event = (
+        _latest_apply_events_query(db).filter(CliUsageEventORM.user_id == uid).first()
     )
-    if analytics and analytics.usage_event_id:
-        event = db.query(CliUsageEventORM).filter(CliUsageEventORM.id == analytics.usage_event_id).first()
-    if event is None or (event.command or "").strip().lower() != "apply":
-        event = (
-            _latest_apply_events_query(db).filter(CliUsageEventORM.user_id == uid).first()
-        )
 
     run_log = _run_log_from_event(event)
     if not run_log and event is not None:
@@ -239,113 +232,7 @@ def get_latest_apply_run_for_user(db: Session, user_id: str) -> Optional[CliAppl
     )
 
 
-def upsert_apply_analytics_grid(
-    db: Session,
-    *,
-    user_id: str,
-    jobs_attempted: int,
-    jobs_submitted: int,
-    jobs_failed: int,
-    last_activity: datetime,
-    usage_event_id: Optional[int] = None,
-    result: Optional[str] = None,
-) -> WboxcliApplyAnalyticsORM:
-    """Upsert one row in wboxcli_apply_analytics (matches AG Grid columns)."""
-    uid = (user_id or "").strip()[:255] or "unknown_user"
-    row = db.query(WboxcliApplyAnalyticsORM).filter(WboxcliApplyAnalyticsORM.user_id == uid).first()
-    if row is None:
-        row = WboxcliApplyAnalyticsORM(
-            user_id=uid,
-            jobs_attempted=int(jobs_attempted or 0),
-            jobs_submitted=int(jobs_submitted or 0),
-            jobs_failed=int(jobs_failed or 0),
-            last_activity=last_activity,
-            usage_event_id=usage_event_id,
-            result=(result or "")[:50] or None,
-        )
-        db.add(row)
-    elif last_activity >= row.last_activity:
-        row.jobs_attempted = int(jobs_attempted or 0)
-        row.jobs_submitted = int(jobs_submitted or 0)
-        row.jobs_failed = int(jobs_failed or 0)
-        row.last_activity = last_activity
-        row.usage_event_id = usage_event_id
-        row.result = (result or "")[:50] or None
-    return row
 
-
-def persist_apply_analytics_from_ingest(
-    db: Session,
-    event_row: CliUsageEventORM,
-    item: CliUsageEventIn,
-) -> None:
-    """Write latest apply snapshot to wboxcli_apply_analytics for apply events."""
-    if (item.command or event_row.command or "").strip().lower() != "apply":
-        return
-    run_log = _extract_apply_run_log(item, event_row)
-    summary = run_log.get("summary") if isinstance(run_log.get("summary"), dict) else {}
-    user_id = (item.user_id or event_row.user_id or "").strip()[:255] or "unknown_user"
-    run_ended = _parse_iso_datetime(run_log.get("run_ended_at")) or event_row.event_ts
-    result = (run_log.get("result") or item.result or event_row.result or "unknown").strip()[:50]
-    jobs_attempted = int(
-        summary.get("jobs_attempted")
-        if summary.get("jobs_attempted") is not None
-        else (item.jobs_attempted_count or event_row.jobs_attempted_count or 0)
-    )
-    jobs_submitted = int(
-        summary.get("jobs_submitted")
-        if summary.get("jobs_submitted") is not None
-        else (item.jobs_submitted_count or event_row.jobs_submitted_count or 0)
-    )
-    jobs_failed = int(
-        summary.get("jobs_failed")
-        if summary.get("jobs_failed") is not None
-        else (item.jobs_failed_count or event_row.jobs_failed_count or 0)
-    )
-    upsert_apply_analytics_grid(
-        db,
-        user_id=user_id,
-        jobs_attempted=jobs_attempted,
-        jobs_submitted=jobs_submitted,
-        jobs_failed=jobs_failed,
-        last_activity=run_ended,
-        usage_event_id=event_row.id,
-        result=result,
-    )
-
-
-def backfill_apply_analytics_from_events(db: Session, *, limit: Optional[int] = None) -> dict:
-    """Populate wboxcli_apply_analytics from historical apply events."""
-    q = (
-        db.query(CliUsageEventORM)
-        .filter(CliUsageEventORM.command == "apply")
-        .order_by(CliUsageEventORM.event_ts.asc())
-    )
-    if limit:
-        q = q.limit(limit)
-    rows = q.all()
-    updated = 0
-    for row in rows:
-        meta = row.event_metadata if isinstance(row.event_metadata, dict) else {}
-        item = CliUsageEventIn(
-            user_id=row.user_id,
-            event_name=row.event_name,
-            event_ts=row.event_ts,
-            command=row.command,
-            result=row.result,
-            duration_ms=row.duration_ms,
-            jobs_attempted_count=row.jobs_attempted_count,
-            jobs_submitted_count=row.jobs_submitted_count,
-            jobs_failed_count=row.jobs_failed_count,
-            metadata=meta,
-        )
-        try:
-            persist_apply_analytics_from_ingest(db, row, item)
-            updated += 1
-        except Exception as exc:
-            logger.warning("Backfill skip event %s: %s", row.id, exc)
-    db.commit()
-    return {"updated": updated, "scanned": len(rows)}
 
 
 def _event_from_input(data: CliUsageEventIn) -> CliUsageEventORM:
@@ -378,14 +265,6 @@ def insert_usage_events_bulk(
             event_row = _event_from_input(item)
             db.add(event_row)
             db.flush()
-            try:
-                persist_apply_analytics_from_ingest(db, event_row, item)
-            except Exception as persist_exc:
-                logger.warning(
-                    "Apply analytics persistence failed for user %s: %s",
-                    item.user_id,
-                    persist_exc,
-                )
             ingested += 1
             if ingested % 50 == 0:
                 db.flush()
@@ -419,21 +298,15 @@ def get_global_summary(db: Session) -> CliUsageAnalyticsSummary:
         .scalar()
         or 0
     )
-    analytics_rows = db.query(WboxcliApplyAnalyticsORM).all()
-    if analytics_rows:
-        total_jobs_attempted = sum(int(r.jobs_attempted or 0) for r in analytics_rows)
-        total_jobs_submitted = sum(int(r.jobs_submitted or 0) for r in analytics_rows)
-        total_jobs_failed = sum(int(r.jobs_failed or 0) for r in analytics_rows)
-    else:
-        latest_apply_rows = _latest_apply_events_query(db).all()
-        total_jobs_attempted = 0
-        total_jobs_submitted = 0
-        total_jobs_failed = 0
-        for row in latest_apply_rows:
-            a, s, f = _counts_from_apply_event(row)
-            total_jobs_attempted += a
-            total_jobs_submitted += s
-            total_jobs_failed += f
+    latest_apply_rows = _latest_apply_events_query(db).all()
+    total_jobs_attempted = 0
+    total_jobs_submitted = 0
+    total_jobs_failed = 0
+    for row in latest_apply_rows:
+        a, s, f = _counts_from_apply_event(row)
+        total_jobs_attempted += a
+        total_jobs_submitted += s
+        total_jobs_failed += f
 
     command_rows = (
         db.query(CliUsageEventORM.command, func.count(CliUsageEventORM.id))
@@ -485,50 +358,10 @@ def get_paginated_users(
     page_size: int = 50,
     user_id: Optional[str] = None,
 ) -> PaginatedCliUsageUsers:
-    """One row per user from wboxcli_apply_analytics (same columns as AG Grid)."""
+    """One row per user from cli_usage_events grouping (same columns as AG Grid)."""
     page = max(1, page)
     page_size = max(1, min(page_size, 500))
 
-    query = db.query(WboxcliApplyAnalyticsORM)
-    if user_id:
-        query = query.filter(WboxcliApplyAnalyticsORM.user_id.ilike(f"%{user_id.strip()}%"))
-
-    total = query.count()
-    analytics = (
-        query.order_by(WboxcliApplyAnalyticsORM.last_activity.desc())
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
-    )
-
-    if analytics:
-        event_ids = [int(r.usage_event_id) for r in analytics if r.usage_event_id]
-        events_by_id: Dict[int, CliUsageEventORM] = {}
-        if event_ids:
-            for ev in db.query(CliUsageEventORM).filter(CliUsageEventORM.id.in_(event_ids)).all():
-                events_by_id[int(ev.id)] = ev
-        users = [
-            _build_cli_usage_user_row(
-                user_id=row.user_id,
-                jobs_attempted=int(row.jobs_attempted or 0),
-                jobs_submitted=int(row.jobs_submitted or 0),
-                jobs_failed=int(row.jobs_failed or 0),
-                last_event_at=row.last_activity,
-                result=row.result,
-                event=events_by_id.get(int(row.usage_event_id))
-                if row.usage_event_id
-                else None,
-            )
-            for row in analytics
-        ]
-        return PaginatedCliUsageUsers(
-            total=int(total),
-            page=page,
-            page_size=page_size,
-            users=users,
-        )
-
-    # Fallback before backfill / first apply ingest
     base = db.query(
         CliUsageEventORM.user_id.label("user_id"),
         func.max(CliUsageEventORM.event_ts).label("last_event_at"),
@@ -576,9 +409,7 @@ def delete_user_usage_events(db: Session, user_id: str) -> CliUsageUserMutationR
     uid = (user_id or "").strip()
     if not uid:
         raise ValueError("user_id is required")
-    db.query(WboxcliApplyAnalyticsORM).filter(WboxcliApplyAnalyticsORM.user_id == uid).delete(
-        synchronize_session=False
-    )
+
     deleted = (
         db.query(CliUsageEventORM)
         .filter(CliUsageEventORM.user_id == uid)
@@ -616,13 +447,7 @@ def update_user_usage_metrics(
     latest.jobs_submitted_count = int(body.jobs_submitted)
     latest.jobs_failed_count = int(body.jobs_failed)
 
-    analytics = (
-        db.query(WboxcliApplyAnalyticsORM).filter(WboxcliApplyAnalyticsORM.user_id == uid).first()
-    )
-    if analytics:
-        analytics.jobs_attempted = int(body.jobs_attempted)
-        analytics.jobs_submitted = int(body.jobs_submitted)
-        analytics.jobs_failed = int(body.jobs_failed)
+
 
     try:
         db.commit()


### PR DESCRIPTION
This PR refactors the CLI analytics modules to eliminate the dependency on the wboxcli_apply_analytics database table. All telemetry summaries and dashboard counts are now calculated dynamically on the fly from the raw cli_usage_events log table.

This enables us to safely drop the wboxcli_apply_analytics table (along with wboxcli_apply_runs and wboxcli_apply_run_jobs) from the database without any service interruption or application crashes.